### PR TITLE
Fix use-after-free bug of DataType value.

### DIFF
--- a/ros/roscpp_core/roscpp_traits/include/ros/protobuffer_traits.h
+++ b/ros/roscpp_core/roscpp_traits/include/ros/protobuffer_traits.h
@@ -69,7 +69,7 @@ struct MD5Sum<T, typename boost::enable_if<boost::is_base_of< ::google::protobuf
 {
   static const char* value() 
   {
-    std::string data_type(DataType<T>::value(), strlen(DataType<T>::value()));
+    std::string data_type(DataType<T>::value());
     if (type_md5_map.count(data_type) == 0) 
     {
       type_md5_map[data_type] = ros::md5::MD5(data_type).toStr();


### PR DESCRIPTION
Everytime when we call DataType<T>::value(), a new string is constructed and assign to the static data_type. So if we call it twice, the first one has been released when we get the second one.

std::string data_type(value1, strlen(value2));

If the compilers which evaluate parameters from left to right, value1 becomes invalid when we get value2, while we still want to use value1 to construct data_type.

This is the simplest fix, which passes a single c_str as parameter.
A better solution is to refactor this whole piece of code, to try to avoid constructing data_type everytime, or avoid c_str.