### PR TITLE
fix log error issue

### DIFF
--- a/ros/class_loader/include/class_loader/class_loader.h
+++ b/ros/class_loader/include/class_loader/class_loader.h
@@ -200,7 +200,7 @@ class ClassLoader
     template <class Base>
     void onPluginDeletion(Base* obj)
     {
-      logDebug("class_loader::ClassLoader: Calling onPluginDeletion() for obj ptr = %p.\n", obj);
+      CONSOLE_BRIDGE_logDebug("class_loader::ClassLoader: Calling onPluginDeletion() for obj ptr = %p.\n", obj);
       if(obj)
       {
         boost::recursive_mutex::scoped_lock lock(plugin_ref_count_mutex_);
@@ -212,7 +212,7 @@ class ClassLoader
           if(!ClassLoader::hasUnmanagedInstanceBeenCreated())
             unloadLibraryInternal(false);
           else
-            logWarn("class_loader::ClassLoader: Cannot unload library %s even though last shared pointer went out of scope. This is because createUnmanagedInstance was used within the scope of this process, perhaps by a different ClassLoader. Library will NOT be closed.", getLibraryPath().c_str());
+            CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader: Cannot unload library %s even though last shared pointer went out of scope. This is because createUnmanagedInstance was used within the scope of this process, perhaps by a different ClassLoader. Library will NOT be closed.", getLibraryPath().c_str());
         }
       }
     }
@@ -234,7 +234,7 @@ class ClassLoader
         has_unmananged_instance_been_created_ = true;
 
       if (managed && ClassLoader::hasUnmanagedInstanceBeenCreated() && isOnDemandLoadUnloadEnabled())
-        logInform("class_loader::ClassLoader: An attempt is being made to create a managed plugin instance (i.e. boost::shared_ptr), however an unmanaged instance was created within this process address space. This means libraries for the managed instances will not be shutdown automatically on final plugin destruction if on demand (lazy) loading/unloading mode is used.");
+        CONSOLE_BRIDGE_logInform("class_loader::ClassLoader: An attempt is being made to create a managed plugin instance (i.e. boost::shared_ptr), however an unmanaged instance was created within this process address space. This means libraries for the managed instances will not be shutdown automatically on final plugin destruction if on demand (lazy) loading/unloading mode is used.");
 
       if (!isLibraryLoaded())
         loadLibrary();

--- a/ros/class_loader/include/class_loader/class_loader_core.h
+++ b/ros/class_loader/include/class_loader/class_loader_core.h
@@ -159,11 +159,11 @@ void registerPlugin(const std::string& class_name, const std::string& base_class
   //Note: This function will be automatically invoked when a dlopen() call
   //opens a library. Normally it will happen within the scope of loadLibrary(),
   //but that may not be guaranteed.
-  logDebug("class_loader.class_loader_private: Registering plugin factory for class = %s, ClassLoader* = %p and library name %s.", class_name.c_str(), getCurrentlyActiveClassLoader(), getCurrentlyLoadingLibraryName().c_str());
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Registering plugin factory for class = %s, ClassLoader* = %p and library name %s.", class_name.c_str(), getCurrentlyActiveClassLoader(), getCurrentlyLoadingLibraryName().c_str());
 
   if(getCurrentlyActiveClassLoader() == NULL)
   {
-    logDebug("class_loader.class_loader_private: ALERT!!! A library containing plugins has been opened through a means other than through the class_loader or pluginlib package. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against). This inherently will trigger a dlopen() prior to main() and cause problems as class_loader is not aware of plugin factories that autoregister under the hood. The class_loader package can compensate, but you may run into namespace collision problems (e.g. if you have the same plugin class in two different libraries and you load them both at the same time). The biggest problem is that library can now no longer be safely unloaded as the ClassLoader does not know when non-plugin code is still in use. In fact, no ClassLoader instance in your application will be unable to unload any library once a non-pure one has been opened. Please refactor your code to isolate plugins into their own libraries.");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: ALERT!!! A library containing plugins has been opened through a means other than through the class_loader or pluginlib package. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against). This inherently will trigger a dlopen() prior to main() and cause problems as class_loader is not aware of plugin factories that autoregister under the hood. The class_loader package can compensate, but you may run into namespace collision problems (e.g. if you have the same plugin class in two different libraries and you load them both at the same time). The biggest problem is that library can now no longer be safely unloaded as the ClassLoader does not know when non-plugin code is still in use. In fact, no ClassLoader instance in your application will be unable to unload any library once a non-pure one has been opened. Please refactor your code to isolate plugins into their own libraries.");
     hasANonPurePluginLibraryBeenOpened(true);    
   }
 
@@ -177,11 +177,11 @@ void registerPlugin(const std::string& class_name, const std::string& base_class
   getPluginBaseToFactoryMapMapMutex().lock();
   FactoryMap& factoryMap = getFactoryMapForBaseClass<Base>();
   if(factoryMap.find(class_name) != factoryMap.end())
-    logWarn("class_loader.class_loader_private: SEVERE WARNING!!! A namespace collision has occured with plugin factory for class %s. New factory will OVERWRITE existing one. This situation occurs when libraries containing plugins are directly linked against an executable (the one running right now generating this message). Please separate plugins out into their own library or just don't link against the library and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.", class_name.c_str());
+    CONSOLE_BRIDGE_logWarn("class_loader.class_loader_private: SEVERE WARNING!!! A namespace collision has occured with plugin factory for class %s. New factory will OVERWRITE existing one. This situation occurs when libraries containing plugins are directly linked against an executable (the one running right now generating this message). Please separate plugins out into their own library or just don't link against the library and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.", class_name.c_str());
   factoryMap[class_name] = new_factory;
   getPluginBaseToFactoryMapMapMutex().unlock();
 
-  logDebug("class_loader.class_loader_private: Registration of %s complete (Metaobject Address = %p)", class_name.c_str(), new_factory);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Registration of %s complete (Metaobject Address = %p)", class_name.c_str(), new_factory);
 }
 
 /**
@@ -201,7 +201,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
     factory = dynamic_cast<class_loader_private::AbstractMetaObject<Base>*>(factoryMap[derived_class_name]);
   else
   {
-    logError("class_loader.class_loader_private: No metaobject exists for class type %s.", derived_class_name.c_str());
+    CONSOLE_BRIDGE_logError("class_loader.class_loader_private: No metaobject exists for class type %s.", derived_class_name.c_str());
   }
   getPluginBaseToFactoryMapMapMutex().unlock();
 
@@ -213,7 +213,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
   {
     if(factory && factory->isOwnedBy(NULL))
     {
-      logDebug("class_loader.class_loader_private: ALERT!!! A metaobject (i.e. factory) exists for desired class, but has no owner. This implies that the library containing the class was dlopen()ed by means other than through the class_loader interface. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() prior to main(). You should isolate your plugins into their own library, otherwise it will not be possible to shutdown the library!");
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: ALERT!!! A metaobject (i.e. factory) exists for desired class, but has no owner. This implies that the library containing the class was dlopen()ed by means other than through the class_loader interface. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() prior to main(). You should isolate your plugins into their own library, otherwise it will not be possible to shutdown the library!");
 
       obj = factory->create();
     }
@@ -221,7 +221,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
       throw(class_loader::CreateClassException("Could not create instance of type " + derived_class_name));
   }
 
-  logDebug("class_loader.class_loader_private: Created instance of type %s and object pointer = %p", (typeid(obj).name()), obj);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Created instance of type %s and object pointer = %p", (typeid(obj).name()), obj);
 
   return(obj);
 }

--- a/ros/class_loader/include/class_loader/class_loader_register_macro.h
+++ b/ros/class_loader/include/class_loader/class_loader_register_macro.h
@@ -43,7 +43,7 @@ namespace \
     ProxyExec##UniqueID() \
     { \
       if(std::string(Message)!="")\
-        logInform("%s", Message);\
+        CONSOLE_BRIDGE_logInform("%s", Message);\
       class_loader::class_loader_private::registerPlugin<_derived, _base>(#Derived, #Base); \
     }\
   };\

--- a/ros/class_loader/include/class_loader/multi_library_class_loader.h
+++ b/ros/class_loader/include/class_loader/multi_library_class_loader.h
@@ -68,7 +68,7 @@ class MultiLibraryClassLoader
     template <class Base>
     boost::shared_ptr<Base> createInstance(const std::string& class_name)
     {
-      logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
+      CONSOLE_BRIDGE_logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
       ClassLoader* loader = getClassLoaderForClass<Base>(class_name);
       if (loader == NULL)
         throw class_loader::CreateClassException("MultiLibraryClassLoader: Could not create object of class type " + class_name + " as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
@@ -103,7 +103,7 @@ class MultiLibraryClassLoader
     template <class Base>
     ClassLoader::UniquePtr<Base> createUniqueInstance(const std::string& class_name)
     {
-      logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
+      CONSOLE_BRIDGE_logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
       ClassLoader* loader = getClassLoaderForClass<Base>(class_name);
       if (loader == nullptr)
         throw class_loader::CreateClassException("MultiLibraryClassLoader: Could not create object of class type " + class_name + " as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");

--- a/ros/class_loader/src/class_loader.cpp
+++ b/ros/class_loader/src/class_loader.cpp
@@ -50,14 +50,14 @@ library_path_(library_path),
 load_ref_count_(0),
 plugin_ref_count_(0)
 {
-  logDebug("class_loader.ClassLoader: Constructing new ClassLoader (%p) bound to library %s.", this, library_path.c_str());
+  CONSOLE_BRIDGE_logDebug("class_loader.ClassLoader: Constructing new ClassLoader (%p) bound to library %s.", this, library_path.c_str());
   if(!isOnDemandLoadUnloadEnabled())
     loadLibrary();
 }
 
 ClassLoader::~ClassLoader()
 {
-  logDebug("class_loader.ClassLoader: Destroying class loader, unloading associated library...\n");
+  CONSOLE_BRIDGE_logDebug("class_loader.ClassLoader: Destroying class loader, unloading associated library...\n");
   unloadLibrary(); //TODO: while(unloadLibrary() > 0){} ??
 }
 
@@ -91,7 +91,7 @@ int ClassLoader::unloadLibraryInternal(bool lock_plugin_ref_count)
     plugin_ref_lock = boost::recursive_mutex::scoped_lock(plugin_ref_count_mutex_);
 
   if(plugin_ref_count_ > 0)
-    logWarn("class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.");
+    CONSOLE_BRIDGE_logWarn("class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.");
   else
   {
     load_ref_count_ = load_ref_count_ - 1;

--- a/ros/class_loader/src/class_loader_core.cpp
+++ b/ros/class_loader/src/class_loader_core.cpp
@@ -220,7 +220,7 @@ MetaObjectVector allMetaObjectsForLibraryOwnedBy(const std::string& library_path
 void insertMetaObjectIntoGraveyard(AbstractMetaObjectBase* meta_obj)
 /*****************************************************************************/
 {
-  logDebug("class_loader.class_loader_private: Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard", meta_obj->className().c_str(), meta_obj->baseClassName().c_str(), meta_obj);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard", meta_obj->className().c_str(), meta_obj->baseClassName().c_str(), meta_obj);
   getMetaObjectGraveyard().push_back(meta_obj);
 }
 
@@ -262,7 +262,7 @@ void destroyMetaObjectsForLibrary(const std::string& library_path, const ClassLo
 {
   boost::recursive_mutex::scoped_lock lock(getPluginBaseToFactoryMapMapMutex());
 
-  logDebug("class_loader.class_loader_private: Removing MetaObjects associated with library %s and class loader %p from global plugin-to-factorymap map.\n", library_path.c_str(), loader);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Removing MetaObjects associated with library %s and class loader %p from global plugin-to-factorymap map.\n", library_path.c_str(), loader);
 
   //We have to walk through all FactoryMaps to be sure
   BaseToFactoryMapMap& factory_map_map = getGlobalPluginBaseToFactoryMapMap();
@@ -270,7 +270,7 @@ void destroyMetaObjectsForLibrary(const std::string& library_path, const ClassLo
   for(itr = factory_map_map.begin(); itr != factory_map_map.end(); itr++)
     destroyMetaObjectsForLibrary(library_path, itr->second, loader);
 
-  logDebug("class_loader.class_loader_private: Metaobjects removed.");
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Metaobjects removed.");
 }
 
 bool areThereAnyExistingMetaObjectsForLibrary(const std::string& library_path)
@@ -351,7 +351,7 @@ void addClassLoaderOwnerForAllExistingMetaObjectsForLibrary(const std::string& l
   for(unsigned int c = 0; c < all_meta_objs.size(); c++)
   {
     AbstractMetaObjectBase* meta_obj = all_meta_objs.at(c);
-    logDebug("class_loader.class_loader_private: Tagging existing MetaObject %p (base = %s, derived = %s) with class loader %p (library path = %s).", meta_obj, meta_obj->baseClassName().c_str(), meta_obj->className().c_str(), loader, loader ? loader->getLibraryPath().c_str() : "NULL");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Tagging existing MetaObject %p (base = %s, derived = %s) with class loader %p (library path = %s).", meta_obj, meta_obj->baseClassName().c_str(), meta_obj->className().c_str(), loader, loader ? loader->getLibraryPath().c_str() : "NULL");
     all_meta_objs.at(c)->addOwningClassLoader(loader);
   }
 }
@@ -367,7 +367,7 @@ void revivePreviouslyCreateMetaobjectsFromGraveyard(const std::string& library_p
     AbstractMetaObjectBase* obj = *itr;
     if(obj->getAssociatedLibraryPath() == library_path)
     {
-      logDebug("class_loader.class_loader_private: Resurrected factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Resurrected factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");
 
       obj->addOwningClassLoader(loader);
       assert(obj->typeidBaseClassName() != "UNSET");
@@ -391,18 +391,18 @@ void purgeGraveyardOfMetaobjects(const std::string& library_path, ClassLoader* l
     AbstractMetaObjectBase* obj = *itr;
     if(obj->getAssociatedLibraryPath() == library_path)
     {
-      logDebug("class_loader.class_loader_private: Purging factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");      
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Purging factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");      
 
       bool is_address_in_graveyard_same_as_global_factory_map = std::find(all_meta_objs.begin(), all_meta_objs.end(), *itr) != all_meta_objs.end();
       itr = graveyard.erase(itr);
       if(delete_objs)
       {
         if(is_address_in_graveyard_same_as_global_factory_map)
-          logDebug("class_loader.class_loader_private: Newly created metaobject factory in global factory map map has same address as one in graveyard -- metaobject has been purged from graveyard but not deleted.");
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Newly created metaobject factory in global factory map map has same address as one in graveyard -- metaobject has been purged from graveyard but not deleted.");
         else
         {
           assert(hasANonPurePluginLibraryBeenOpened() == false);
-          logDebug("class_loader.class_loader_private: Also destroying metaobject %p (class = %s, base_class = %s, library_path = %s) in addition to purging it from graveyard.", obj, obj->className().c_str(), obj->baseClassName().c_str(), obj->getAssociatedLibraryPath().c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Also destroying metaobject %p (class = %s, base_class = %s, library_path = %s) in addition to purging it from graveyard.", obj, obj->className().c_str(), obj->baseClassName().c_str(), obj->getAssociatedLibraryPath().c_str());
           delete(obj); //Note: This is the only place where metaobjects can be destroyed
         }
       }
@@ -416,14 +416,14 @@ void loadLibrary(const std::string& library_path, ClassLoader* loader)
 /*****************************************************************************/
 {
   static boost::recursive_mutex loader_mutex;
-  logDebug("class_loader.class_loader_private: Attempting to load library %s on behalf of ClassLoader handle %p...\n", library_path.c_str(), loader);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Attempting to load library %s on behalf of ClassLoader handle %p...\n", library_path.c_str(), loader);
   boost::recursive_mutex::scoped_lock loader_lock(loader_mutex);
 
   //If it's already open, just update existing metaobjects to have an additional owner.
   if(isLibraryLoadedByAnybody(library_path))
   {
     boost::recursive_mutex::scoped_lock lock(getPluginBaseToFactoryMapMapMutex());
-    logDebug("class_loader.class_loader_private: Library already in memory, but binding existing MetaObjects to loader if necesesary.\n");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Library already in memory, but binding existing MetaObjects to loader if necesesary.\n");
     addClassLoaderOwnerForAllExistingMetaObjectsForLibrary(library_path, loader);
     return;
   }
@@ -462,19 +462,19 @@ void loadLibrary(const std::string& library_path, ClassLoader* loader)
   }
 
   assert(library_handle != NULL);
-  logDebug("class_loader.class_loader_private: Successfully loaded library %s into memory (Poco::SharedLibrary handle = %p).", library_path.c_str(), library_handle);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Successfully loaded library %s into memory (Poco::SharedLibrary handle = %p).", library_path.c_str(), library_handle);
 
   //Graveyard scenario
   unsigned int num_lib_objs = allMetaObjectsForLibrary(library_path).size();
   if(num_lib_objs == 0)
   {
-    logDebug("class_loader.class_loader_private: Though the library %s was just loaded, it seems no factory metaobjects were registered. Checking factory graveyard for previously loaded metaobjects...", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Though the library %s was just loaded, it seems no factory metaobjects were registered. Checking factory graveyard for previously loaded metaobjects...", library_path.c_str());
     revivePreviouslyCreateMetaobjectsFromGraveyard(library_path, loader);
     purgeGraveyardOfMetaobjects(library_path, loader, false); //Note: The 'false' indicates we don't want to invoke delete on the metaobject
   }
   else
   {
-    logDebug("class_loader.class_loader_private: Library %s generated new factory metaobjects on load. Destroying graveyarded objects from previous loads...", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Library %s generated new factory metaobjects on load. Destroying graveyarded objects from previous loads...", library_path.c_str());
     purgeGraveyardOfMetaobjects(library_path, loader, true);
   }
 
@@ -489,11 +489,11 @@ void unloadLibrary(const std::string& library_path, ClassLoader* loader)
 { 
   if(hasANonPurePluginLibraryBeenOpened())
   {
-    logDebug("class_loader.class_loader_private: Cannot unload %s or ANY other library as a non-pure plugin library was opened. As class_loader has no idea which libraries class factories were exported from, it can safely close any library without potentially unlinking symbols that are still actively being used. You must refactor your plugin libraries to be made exclusively of plugins in order for this error to stop happening.", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Cannot unload %s or ANY other library as a non-pure plugin library was opened. As class_loader has no idea which libraries class factories were exported from, it can safely close any library without potentially unlinking symbols that are still actively being used. You must refactor your plugin libraries to be made exclusively of plugins in order for this error to stop happening.", library_path.c_str());
   }
   else
   { 
-    logDebug("class_loader.class_loader_private: Unloading library %s on behalf of ClassLoader %p...", library_path.c_str(), loader);
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Unloading library %s on behalf of ClassLoader %p...", library_path.c_str(), loader);
     boost::recursive_mutex::scoped_lock lock(getLoadedLibraryVectorMutex());
     LibraryVector& open_libraries =  getLoadedLibraryVector();
     LibraryVector::iterator itr = findLoadedLibrary(library_path);
@@ -508,14 +508,14 @@ void unloadLibrary(const std::string& library_path, ClassLoader* loader)
         //Remove from loaded library list as well if no more factories associated with said library
         if(!areThereAnyExistingMetaObjectsForLibrary(library_path))
         {
-          logDebug("class_loader.class_loader_private: There are no more MetaObjects left for %s so unloading library and removing from loaded library vector.\n", library_path.c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: There are no more MetaObjects left for %s so unloading library and removing from loaded library vector.\n", library_path.c_str());
           library->unload();          
           assert(library->isLoaded() == false);
           delete(library);
           itr = open_libraries.erase(itr);
         }
         else
-          logDebug("class_loader.class_loader_private: MetaObjects still remain in memory meaning other ClassLoaders are still using library, keeping library %s open.", library_path.c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: MetaObjects still remain in memory meaning other ClassLoaders are still using library, keeping library %s open.", library_path.c_str());
         return;
       }
       catch(const Poco::RuntimeException& e)

--- a/ros/class_loader/src/meta_object.cpp
+++ b/ros/class_loader/src/meta_object.cpp
@@ -42,13 +42,13 @@ class_name_(class_name),
 typeid_base_class_name_("UNSET")
 /*****************************************************************************/
 {
-    logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Creating MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Creating MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
 }
 
 AbstractMetaObjectBase::~AbstractMetaObjectBase()
 /*****************************************************************************/
 {
-    logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Destroying MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Destroying MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
 } 
 
 std::string AbstractMetaObjectBase::className() const

--- a/ros/geometry2/tf2/src/buffer_core.cpp
+++ b/ros/geometry2/tf2/src/buffer_core.cpp
@@ -119,7 +119,7 @@ bool BufferCore::warnFrameId(const char* function_name_arg, const std::string& f
   {
     std::stringstream ss;
     ss << "Invalid argument passed to "<< function_name_arg <<" in tf2 frame_ids cannot be empty";
-    logWarn("%s",ss.str().c_str());
+    CONSOLE_BRIDGE_logWarn("%s",ss.str().c_str());
     return true;
   }
 
@@ -127,7 +127,7 @@ bool BufferCore::warnFrameId(const char* function_name_arg, const std::string& f
   {
     std::stringstream ss;
     ss << "Invalid argument \"" << frame_id << "\" passed to "<< function_name_arg <<" in tf2 frame_ids cannot start with a '/' like: ";
-    logWarn("%s",ss.str().c_str());
+    CONSOLE_BRIDGE_logWarn("%s",ss.str().c_str());
     return true;
   }
 
@@ -214,26 +214,26 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
   bool error_exists = false;
   if (stripped.child_frame_id == stripped.header.frame_id)
   {
-    logError("TF_SELF_TRANSFORM: Ignoring transform from authority \"%s\" with frame_id and child_frame_id  \"%s\" because they are the same",  authority.c_str(), stripped.child_frame_id.c_str());
+    CONSOLE_BRIDGE_logError("TF_SELF_TRANSFORM: Ignoring transform from authority \"%s\" with frame_id and child_frame_id  \"%s\" because they are the same",  authority.c_str(), stripped.child_frame_id.c_str());
     error_exists = true;
   }
 
   if (stripped.child_frame_id == "")
   {
-    logError("TF_NO_CHILD_FRAME_ID: Ignoring transform from authority \"%s\" because child_frame_id not set ", authority.c_str());
+    CONSOLE_BRIDGE_logError("TF_NO_CHILD_FRAME_ID: Ignoring transform from authority \"%s\" because child_frame_id not set ", authority.c_str());
     error_exists = true;
   }
 
   if (stripped.header.frame_id == "")
   {
-    logError("TF_NO_FRAME_ID: Ignoring transform with child_frame_id \"%s\"  from authority \"%s\" because frame_id not set", stripped.child_frame_id.c_str(), authority.c_str());
+    CONSOLE_BRIDGE_logError("TF_NO_FRAME_ID: Ignoring transform with child_frame_id \"%s\"  from authority \"%s\" because frame_id not set", stripped.child_frame_id.c_str(), authority.c_str());
     error_exists = true;
   }
 
   if (std::isnan(stripped.transform.translation.x) || std::isnan(stripped.transform.translation.y) || std::isnan(stripped.transform.translation.z)||
       std::isnan(stripped.transform.rotation.x) ||       std::isnan(stripped.transform.rotation.y) ||       std::isnan(stripped.transform.rotation.z) ||       std::isnan(stripped.transform.rotation.w))
   {
-    logError("TF_NAN_INPUT: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of a nan value in the transform (%f %f %f) (%f %f %f %f)",
+    CONSOLE_BRIDGE_logError("TF_NAN_INPUT: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of a nan value in the transform (%f %f %f) (%f %f %f %f)",
               stripped.child_frame_id.c_str(), authority.c_str(),
               stripped.transform.translation.x, stripped.transform.translation.y, stripped.transform.translation.z,
               stripped.transform.rotation.x, stripped.transform.rotation.y, stripped.transform.rotation.z, stripped.transform.rotation.w
@@ -257,7 +257,7 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
     }
     else
     {
-      logWarn("TF_OLD_DATA ignoring data from the past for frame %s at time %g according to authority %s\nPossible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained", stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      CONSOLE_BRIDGE_logWarn("TF_OLD_DATA ignoring data from the past for frame %s at time %g according to authority %s\nPossible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained", stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
       return false;
     }
   }
@@ -605,7 +605,7 @@ geometry_msgs::TransformStamped BufferCore::lookupTransform(const std::string& t
     case tf2_msgs::TF2Error::LOOKUP_ERROR:
       throw LookupException(error_string);
     default:
-      logError("Unknown error code: %d", retval);
+      CONSOLE_BRIDGE_logError("Unknown error code: %d", retval);
       assert(0);
     }
   }
@@ -1496,7 +1496,7 @@ void BufferCore::_chainAsVector(const std::string & target_frame, ros::Time targ
     case tf2_msgs::TF2Error::LOOKUP_ERROR:
       throw LookupException(error_string);
     default:
-      logError("Unknown error code: %d", retval);
+      CONSOLE_BRIDGE_logError("Unknown error code: %d", retval);
       assert(0);
     }
   }
@@ -1516,7 +1516,7 @@ void BufferCore::_chainAsVector(const std::string & target_frame, ros::Time targ
       case tf2_msgs::TF2Error::LOOKUP_ERROR:
         throw LookupException(error_string);
       default:
-        logError("Unknown error code: %d", retval);
+        CONSOLE_BRIDGE_logError("Unknown error code: %d", retval);
         assert(0);
       }
     }

--- a/ros/ros_comm/rosbag_storage/include/rosbag/bag.h
+++ b/ros/ros_comm/rosbag_storage/include/rosbag/bag.h
@@ -591,7 +591,7 @@ void Bag::doWrite(std::string const& topic, ros::Time const& time,
 
         // Check if we want to stop this chunk
         uint32_t chunk_size = getChunkOffset();
-        logDebug("  curr_chunk_size=%d (threshold=%d)", chunk_size, chunk_threshold_);
+        CONSOLE_BRIDGE_logDebug("  curr_chunk_size=%d (threshold=%d)", chunk_size, chunk_threshold_);
         if (chunk_size > chunk_threshold_) {
             // Empty the outgoing chunk
             stopWritingChunk();
@@ -626,7 +626,7 @@ void Bag::writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T cons
     seek(0, std::ios::end);
     file_size_ = file_.getOffset();
 
-    logDebug("Writing MSG_DATA [%llu:%d]: conn=%d sec=%d nsec=%d data_len=%d",
+    CONSOLE_BRIDGE_logDebug("Writing MSG_DATA [%llu:%d]: conn=%d sec=%d nsec=%d data_len=%d",
               (unsigned long long) file_.getOffset(), getChunkOffset(), conn_id, time.sec, time.nsec, msg_ser_len);
 
     writeHeader(header);

--- a/ros/ros_comm/rosbag_storage/src/bag.cpp
+++ b/ros/ros_comm/rosbag_storage/src/bag.cpp
@@ -213,7 +213,7 @@ void Bag::setCompression(CompressionType compression) {
 void Bag::writeVersion() {
     string version = string("#ROSBAG V") + VERSION + string("\n");
 
-    logDebug("Writing VERSION [%llu]: %s", (unsigned long long) file_.getOffset(), version.c_str());
+    CONSOLE_BRIDGE_logDebug("Writing VERSION [%llu]: %s", (unsigned long long) file_.getOffset(), version.c_str());
 
     version_ = 200;
 
@@ -236,7 +236,7 @@ void Bag::readVersion() {
 
     version_ = version_major * 100 + version_minor;
 
-    logDebug("Read VERSION: version=%d", version_);
+    CONSOLE_BRIDGE_logDebug("Read VERSION: version=%d", version_);
 }
 
 uint32_t Bag::getMajorVersion() const { return version_ / 100; }
@@ -325,7 +325,7 @@ void Bag::startReadingVersion102() {
         multiset<IndexEntry> const& index       = i->second;
         IndexEntry const&           first_entry = *index.begin();
 
-        logDebug("Reading message definition for connection %d at %llu", i->first, (unsigned long long) first_entry.chunk_pos);
+        CONSOLE_BRIDGE_logDebug("Reading message definition for connection %d at %llu", i->first, (unsigned long long) first_entry.chunk_pos);
 
         seek(first_entry.chunk_pos);
 
@@ -339,7 +339,7 @@ void Bag::writeFileHeaderRecord() {
     connection_count_ = connections_.size();
     chunk_count_      = chunks_.size();
 
-    logDebug("Writing FILE_HEADER [%llu]: index_pos=%llu connection_count=%d chunk_count=%d",
+    CONSOLE_BRIDGE_logDebug("Writing FILE_HEADER [%llu]: index_pos=%llu connection_count=%d chunk_count=%d",
               (unsigned long long) file_.getOffset(), (unsigned long long) index_data_pos_, connection_count_, chunk_count_);
     
     // Write file header record
@@ -390,7 +390,7 @@ void Bag::readFileHeaderRecord() {
         readField(fields, CHUNK_COUNT_FIELD_NAME,      true, &chunk_count_);
     }
 
-    logDebug("Read FILE_HEADER: index_pos=%llu connection_count=%d chunk_count=%d",
+    CONSOLE_BRIDGE_logDebug("Read FILE_HEADER: index_pos=%llu connection_count=%d chunk_count=%d",
               (unsigned long long) index_data_pos_, connection_count_, chunk_count_);
 
     // Skip the data section (just padding)
@@ -460,7 +460,7 @@ void Bag::writeChunkHeader(CompressionType compression, uint32_t compressed_size
     chunk_header.compressed_size   = compressed_size;
     chunk_header.uncompressed_size = uncompressed_size;
 
-    logDebug("Writing CHUNK [%llu]: compression=%s compressed=%d uncompressed=%d",
+    CONSOLE_BRIDGE_logDebug("Writing CHUNK [%llu]: compression=%s compressed=%d uncompressed=%d",
               (unsigned long long) file_.getOffset(), chunk_header.compression.c_str(), chunk_header.compressed_size, chunk_header.uncompressed_size);
 
     M_string header;
@@ -485,7 +485,7 @@ void Bag::readChunkHeader(ChunkHeader& chunk_header) const {
     readField(fields, COMPRESSION_FIELD_NAME, true, chunk_header.compression);
     readField(fields, SIZE_FIELD_NAME,        true, &chunk_header.uncompressed_size);
 
-    logDebug("Read CHUNK: compression=%s size=%d uncompressed=%d (%f)", chunk_header.compression.c_str(), chunk_header.compressed_size, chunk_header.uncompressed_size, 100 * ((double) chunk_header.compressed_size) / chunk_header.uncompressed_size);
+    CONSOLE_BRIDGE_logDebug("Read CHUNK: compression=%s size=%d uncompressed=%d (%f)", chunk_header.compression.c_str(), chunk_header.compressed_size, chunk_header.uncompressed_size, 100 * ((double) chunk_header.compressed_size) / chunk_header.uncompressed_size);
 }
 
 // Index records
@@ -506,7 +506,7 @@ void Bag::writeIndexRecords() {
 
         writeDataLength(index_size * 12);
 
-        logDebug("Writing INDEX_DATA: connection=%d ver=%d count=%d", connection_id, INDEX_VERSION, index_size);
+        CONSOLE_BRIDGE_logDebug("Writing INDEX_DATA: connection=%d ver=%d count=%d", connection_id, INDEX_VERSION, index_size);
 
         // Write the index record data (pairs of timestamp and position in file)
         foreach(IndexEntry const& e, index) {
@@ -514,7 +514,7 @@ void Bag::writeIndexRecords() {
             write((char*) &e.time.nsec, 4);
             write((char*) &e.offset,    4);
 
-            logDebug("  - %d.%d: %d", e.time.sec, e.time.nsec, e.offset);
+            CONSOLE_BRIDGE_logDebug("  - %d.%d: %d", e.time.sec, e.time.nsec, e.offset);
         }
     }
 }
@@ -536,7 +536,7 @@ void Bag::readTopicIndexRecord102() {
     readField(fields, TOPIC_FIELD_NAME, true, topic);
     readField(fields, COUNT_FIELD_NAME, true, &count);
 
-    logDebug("Read INDEX_DATA: ver=%d topic=%s count=%d", index_version, topic.c_str(), count);
+    CONSOLE_BRIDGE_logDebug("Read INDEX_DATA: ver=%d topic=%s count=%d", index_version, topic.c_str(), count);
 
     if (index_version != 0)
         throw BagFormatException((format("Unsupported INDEX_DATA version: %1%") % index_version).str());
@@ -546,7 +546,7 @@ void Bag::readTopicIndexRecord102() {
     if (topic_conn_id_iter == topic_connection_ids_.end()) {
     	connection_id = connections_.size();
 
-        logDebug("Creating connection: id=%d topic=%s", connection_id, topic.c_str());
+        CONSOLE_BRIDGE_logDebug("Creating connection: id=%d topic=%s", connection_id, topic.c_str());
         ConnectionInfo* connection_info = new ConnectionInfo();
         connection_info->id       = connection_id;
         connection_info->topic    = topic;
@@ -569,11 +569,11 @@ void Bag::readTopicIndexRecord102() {
         index_entry.time = Time(sec, nsec);
         index_entry.offset = 0;
 
-        logDebug("  - %d.%d: %llu", sec, nsec, (unsigned long long) index_entry.chunk_pos);
+        CONSOLE_BRIDGE_logDebug("  - %d.%d: %llu", sec, nsec, (unsigned long long) index_entry.chunk_pos);
 
         if (index_entry.time < ros::TIME_MIN || index_entry.time > ros::TIME_MAX)
         {
-          logError("Index entry for topic %s contains invalid time.", topic.c_str());
+          CONSOLE_BRIDGE_logError("Index entry for topic %s contains invalid time.", topic.c_str());
         } else
         {
           connection_index.insert(connection_index.end(), index_entry);
@@ -598,7 +598,7 @@ void Bag::readConnectionIndexRecord200() {
     readField(fields, CONNECTION_FIELD_NAME, true, &connection_id);
     readField(fields, COUNT_FIELD_NAME,      true, &count);
 
-    logDebug("Read INDEX_DATA: ver=%d connection=%d count=%d", index_version, connection_id, count);
+    CONSOLE_BRIDGE_logDebug("Read INDEX_DATA: ver=%d connection=%d count=%d", index_version, connection_id, count);
 
     if (index_version != 1)
         throw BagFormatException((format("Unsupported INDEX_DATA version: %1%") % index_version).str());
@@ -617,11 +617,11 @@ void Bag::readConnectionIndexRecord200() {
         read((char*) &index_entry.offset, 4);
         index_entry.time = Time(sec, nsec);
 
-        logDebug("  - %d.%d: %llu+%d", sec, nsec, (unsigned long long) index_entry.chunk_pos, index_entry.offset);
+        CONSOLE_BRIDGE_logDebug("  - %d.%d: %llu+%d", sec, nsec, (unsigned long long) index_entry.chunk_pos, index_entry.offset);
 
         if (index_entry.time < ros::TIME_MIN || index_entry.time > ros::TIME_MAX)
         {
-          logError("Index entry for topic %s contains invalid time.  This message will not be loaded.", connections_[connection_id]->topic.c_str());
+          CONSOLE_BRIDGE_logError("Index entry for topic %s contains invalid time.  This message will not be loaded.", connections_[connection_id]->topic.c_str());
         } else
         {
           connection_index.insert(connection_index.end(), index_entry);
@@ -639,7 +639,7 @@ void Bag::writeConnectionRecords() {
 }
 
 void Bag::writeConnectionRecord(ConnectionInfo const* connection_info) {
-    logDebug("Writing CONNECTION [%llu:%d]: topic=%s id=%d",
+    CONSOLE_BRIDGE_logDebug("Writing CONNECTION [%llu:%d]: topic=%s id=%d",
               (unsigned long long) file_.getOffset(), getChunkOffset(), connection_info->topic.c_str(), connection_info->id);
 
     M_string header;
@@ -701,7 +701,7 @@ void Bag::readConnectionRecord() {
         connection_info->md5sum   = (*connection_info->header)["md5sum"];
         connections_[id] = connection_info;
 
-        logDebug("Read CONNECTION: topic=%s id=%d", topic.c_str(), id);
+        CONSOLE_BRIDGE_logDebug("Read CONNECTION: topic=%s id=%d", topic.c_str(), id);
     }
 }
 
@@ -727,7 +727,7 @@ void Bag::readMessageDefinitionRecord102() {
     if (topic_conn_id_iter == topic_connection_ids_.end()) {
     	uint32_t id = connections_.size();
 
-        logDebug("Creating connection: topic=%s md5sum=%s datatype=%s", topic.c_str(), md5sum.c_str(), datatype.c_str());
+        CONSOLE_BRIDGE_logDebug("Creating connection: topic=%s md5sum=%s datatype=%s", topic.c_str(), md5sum.c_str(), datatype.c_str());
         connection_info = new ConnectionInfo();
         connection_info->id       = id;
         connection_info->topic    = topic;
@@ -746,7 +746,7 @@ void Bag::readMessageDefinitionRecord102() {
     (*connection_info->header)["md5sum"]             = connection_info->md5sum;
     (*connection_info->header)["message_definition"] = connection_info->msg_def;
 
-    logDebug("Read MSG_DEF: topic=%s md5sum=%s datatype=%s", topic.c_str(), md5sum.c_str(), datatype.c_str());
+    CONSOLE_BRIDGE_logDebug("Read MSG_DEF: topic=%s md5sum=%s datatype=%s", topic.c_str(), md5sum.c_str(), datatype.c_str());
 }
 
 void Bag::decompressChunk(uint64_t chunk_pos) const {
@@ -781,7 +781,7 @@ void Bag::decompressChunk(uint64_t chunk_pos) const {
 }
 
 void Bag::readMessageDataRecord102(uint64_t offset, ros::Header& header) const {
-    logDebug("readMessageDataRecord: offset=%llu", (unsigned long long) offset);
+    CONSOLE_BRIDGE_logDebug("readMessageDataRecord: offset=%llu", (unsigned long long) offset);
 
     seek(offset);
 
@@ -807,7 +807,7 @@ void Bag::decompressRawChunk(ChunkHeader const& chunk_header) const {
     assert(chunk_header.compression == COMPRESSION_NONE);
     assert(chunk_header.compressed_size == chunk_header.uncompressed_size);
 
-    logDebug("compressed_size: %d uncompressed_size: %d", chunk_header.compressed_size, chunk_header.uncompressed_size);
+    CONSOLE_BRIDGE_logDebug("compressed_size: %d uncompressed_size: %d", chunk_header.compressed_size, chunk_header.uncompressed_size);
 
     decompress_buffer_.setSize(chunk_header.compressed_size);
     file_.read((char*) decompress_buffer_.getData(), chunk_header.compressed_size);
@@ -820,7 +820,7 @@ void Bag::decompressBz2Chunk(ChunkHeader const& chunk_header) const {
 
     CompressionType compression = compression::BZ2;
 
-    logDebug("compressed_size: %d uncompressed_size: %d", chunk_header.compressed_size, chunk_header.uncompressed_size);
+    CONSOLE_BRIDGE_logDebug("compressed_size: %d uncompressed_size: %d", chunk_header.compressed_size, chunk_header.uncompressed_size);
 
     chunk_buffer_.setSize(chunk_header.compressed_size);
     file_.read((char*) chunk_buffer_.getData(), chunk_header.compressed_size);
@@ -836,7 +836,7 @@ void Bag::decompressLz4Chunk(ChunkHeader const& chunk_header) const {
 
     CompressionType compression = compression::LZ4;
 
-    logDebug("lz4 compressed_size: %d uncompressed_size: %d",
+    CONSOLE_BRIDGE_logDebug("lz4 compressed_size: %d uncompressed_size: %d",
              chunk_header.compressed_size, chunk_header.uncompressed_size);
 
     chunk_buffer_.setSize(chunk_header.compressed_size);
@@ -897,7 +897,7 @@ void Bag::writeChunkInfoRecords() {
         header[END_TIME_FIELD_NAME]   = toHeaderString(&chunk_info.end_time);
         header[COUNT_FIELD_NAME]      = toHeaderString(&chunk_connection_count);
 
-        logDebug("Writing CHUNK_INFO [%llu]: ver=%d pos=%llu start=%d.%d end=%d.%d",
+        CONSOLE_BRIDGE_logDebug("Writing CHUNK_INFO [%llu]: ver=%d pos=%llu start=%d.%d end=%d.%d",
                   (unsigned long long) file_.getOffset(), CHUNK_INFO_VERSION, (unsigned long long) chunk_info.pos,
                   chunk_info.start_time.sec, chunk_info.start_time.nsec,
                   chunk_info.end_time.sec, chunk_info.end_time.nsec);
@@ -914,7 +914,7 @@ void Bag::writeChunkInfoRecords() {
             write((char*) &connection_id, 4);
             write((char*) &count, 4);
 
-            logDebug("  - %d: %d", connection_id, count);
+            CONSOLE_BRIDGE_logDebug("  - %d: %d", connection_id, count);
         }
     }
 }
@@ -943,7 +943,7 @@ void Bag::readChunkInfoRecord() {
     uint32_t chunk_connection_count = 0;
     readField(fields, COUNT_FIELD_NAME,      true, &chunk_connection_count);
 
-    logDebug("Read CHUNK_INFO: chunk_pos=%llu connection_count=%d start=%d.%d end=%d.%d",
+    CONSOLE_BRIDGE_logDebug("Read CHUNK_INFO: chunk_pos=%llu connection_count=%d start=%d.%d end=%d.%d",
               (unsigned long long) chunk_info.pos, chunk_connection_count,
               chunk_info.start_time.sec, chunk_info.start_time.nsec,
               chunk_info.end_time.sec, chunk_info.end_time.nsec);
@@ -954,7 +954,7 @@ void Bag::readChunkInfoRecord() {
         read((char*) &connection_id,    4);
         read((char*) &connection_count, 4);
 
-        logDebug("  %d: %d messages", connection_id, connection_count);
+        CONSOLE_BRIDGE_logDebug("  %d: %d messages", connection_id, connection_count);
 
         chunk_info.connection_counts[connection_id] = connection_count;
     }
@@ -1036,7 +1036,7 @@ void Bag::readMessageDataHeaderFromBuffer(Buffer& buffer, uint32_t offset, ros::
     total_bytes_read = 0;
     uint8_t op = 0xFF;
     do {
-        logDebug("reading header from buffer: offset=%d", offset);
+        CONSOLE_BRIDGE_logDebug("reading header from buffer: offset=%d", offset);
         uint32_t bytes_read;
         readHeaderFromBuffer(*current_buffer_, offset, header, data_size, bytes_read);
 

--- a/ros/ros_comm/rosbag_storage/src/bz2_stream.cpp
+++ b/ros/ros_comm/rosbag_storage/src/bz2_stream.cpp
@@ -115,7 +115,7 @@ void BZ2Stream::read(void* ptr, size_t size) {
     case BZ_OK: return;
     case BZ_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             char* unused;
             int nUnused;

--- a/ros/ros_comm/rosbag_storage/src/lz4_stream.cpp
+++ b/ros/ros_comm/rosbag_storage/src/lz4_stream.cpp
@@ -155,7 +155,7 @@ void LZ4Stream::read(void* ptr, size_t size) {
     case ROSLZ4_OK: break;
     case ROSLZ4_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             setUnused(lz4s_.input_next);
             setUnusedLength(lz4s_.input_left);

--- a/ros/roscpp_core/cpp_common/src/header.cpp
+++ b/ros/roscpp_core/cpp_common/src/header.cpp
@@ -79,7 +79,7 @@ bool Header::parse(uint8_t* buffer, uint32_t size, std::string& error_msg)
     if (len > 1000000)
     {
       error_msg = "Received an invalid TCPROS header.  Each element must be prepended by a 4-byte length.";
-      logError("%s", error_msg.c_str());
+      CONSOLE_BRIDGE_logError("%s", error_msg.c_str());
 
       return false;
     }
@@ -93,7 +93,7 @@ bool Header::parse(uint8_t* buffer, uint32_t size, std::string& error_msg)
     if (eqpos == string::npos)
     {
       error_msg = "Received an invalid TCPROS header.  Each line must have an equals sign.";
-      logError("%s", error_msg.c_str());
+      CONSOLE_BRIDGE_logError("%s", error_msg.c_str());
 
       return false;
     }


### PR DESCRIPTION
Update logError, logWarn, logDebug, logInform with CONSOLE_BRIDGE_
prefixed to avoid errors:

"ros/class_loader/include/class_loader/class_loader_core.h:204:118:
error: there are no arguments to ‘logError’ that depend on a template
parameter, so a declaration of ‘logError’ must be available
[-fpermissive]"

"ros/class_loader/include/class_loader/class_loader_core.h:180:511:
error: there are no arguments to ‘logWarn’ that depend on a template
parameter, so a declaration of ‘logWarn’ must be available
[-fpermissive]"

"ros/class_loader/include/class_loader/multi_library_class_loader.h:71:124:
error: there are no arguments to ‘logDebug’ that depend on a template
parameter, so a declaration of ‘logDebug’ must be available
[-fpermissive]"

etc.