### PR TITLE
fix ros::master::getTopics() getting worng results

### DIFF
--- a/ros/ros_comm/roscpp/src/libros/broadcast_manager.cpp
+++ b/ros/ros_comm/roscpp/src/libros/broadcast_manager.cpp
@@ -156,8 +156,9 @@ void BroadcastManager::registerPublisherCallback(const MsgInfo& result)
 {
   std::string topic_name = result.get<std::string>(TOPIC_NAME);
   std::string pub_uri = result.get<std::string>(XMLRPC_URI);
+  std::string data_type = result.get<std::string>(TOPIC_TYPE);
   pub_cache_[topic_name].insert(pub_uri);
-  topic_cache_.emplace_back(topic_name, pub_uri);
+  topic_cache_.emplace_back(topic_name, data_type);
   publisherUpdate(topic_name);
 }
 


### PR DESCRIPTION
The declaration of ros::master::getTopic says that each item in the result is a pair <string topic, string **type**>,  but in the implementation the item is a pair of <string topic, string uri> which is conflict with declaration.

Besides, the TopicInfo is a container of topic name and **datatype**, not **uri**
