### PR TITLE
fix minor errr in message_event.h

### DIFF
--- a/ros/roscpp_core/roscpp_traits/include/ros/message_event.h
+++ b/ros/roscpp_core/roscpp_traits/include/ros/message_event.h
@@ -200,7 +200,7 @@ public:
 
   bool operator==(const MessageEvent<M>& rhs)
   {
-    return message_ = rhs.message_ && receipt_time_ == rhs.receipt_time_ && nonconst_need_copy_ == rhs.nonconst_need_copy_;
+    return message_ == rhs.message_ && receipt_time_ == rhs.receipt_time_ && nonconst_need_copy_ == rhs.nonconst_need_copy_;
   }
 
   bool operator!=(const MessageEvent<M>& rhs)


### PR DESCRIPTION
Line 203: assignment symbo should be 'equal to' symbol 